### PR TITLE
Remove double quotation marks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you want to more later version of Node (example v0.9.1), you can change
 to that by just writing it to the end of the NODEJS_VERSION file and
 committing that change.
 
-    echo "0.9.1" >> .openshift/markers/NODEJS_VERSION
+    echo 0.9.1 >> .openshift/markers/NODEJS_VERSION
     git commit . -m 'use Node version 0.9.1'
 
 Then push the repo to OpenShift


### PR DESCRIPTION
On running the following command...

``` javascript
echo "0.9.1" >> .openshift/markers/NODEJS_VERSION
```

you get the NODE_JS file with has "0.9.1" in double quotation marks while it should contain 0.9.1 without quotation marks as shown in your  repository.
