### PR TITLE
fixed typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "homepage": "http://www.openshift.com/",
   "repository": {
     "type": "git",
-    "url": "https://gitub.com/ramr/nodejs-custom-version-openshift"
+    "url": "https://github.com/ramr/nodejs-custom-version-openshift"
   },
 
   "engines": {


### PR DESCRIPTION
There was a typo in the repository url value. Changed from gitub to github. 
